### PR TITLE
feat: add dedicated pages for tx and addresses

### DIFF
--- a/app/address/[address]/page.tsx
+++ b/app/address/[address]/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from "next/navigation";
+import { createPublicClient, formatEther, http } from "viem";
+import Search from "@/components/search";
+
+const client = createPublicClient({
+  transport: http(process.env.NEXT_PUBLIC_RPC_URL || ""),
+});
+
+export default async function AddressPage({
+  params,
+}: {
+  params: { address: string };
+}) {
+  const address = params.address as `0x${string}`;
+  try {
+    const [balance, code] = await Promise.all([
+      client.getBalance({ address }),
+      client.getCode({ address }),
+    ]);
+    const isContract = code !== "0x";
+    return (
+      <main className="mx-auto max-w-5xl p-6">
+        <Search />
+        <h1 className="mb-4 text-2xl font-semibold">
+          {isContract ? "Contract" : "Address"} Details
+        </h1>
+        <div className="rounded border p-4">
+          <div className="mb-2 break-all font-mono">{address}</div>
+          <div>Balance: {formatEther(balance)} PGC</div>
+          <div>Type: {isContract ? "Contract" : "Externally Owned Account"}</div>
+        </div>
+      </main>
+    );
+  } catch {
+    notFound();
+  }
+}

--- a/app/contract/[address]/page.tsx
+++ b/app/contract/[address]/page.tsx
@@ -1,0 +1,36 @@
+import { notFound } from "next/navigation";
+import { createPublicClient, formatEther, http } from "viem";
+import Search from "@/components/search";
+
+const client = createPublicClient({
+  transport: http(process.env.NEXT_PUBLIC_RPC_URL || ""),
+});
+
+export default async function ContractPage({
+  params,
+}: {
+  params: { address: string };
+}) {
+  const address = params.address as `0x${string}`;
+  try {
+    const [balance, code] = await Promise.all([
+      client.getBalance({ address }),
+      client.getCode({ address }),
+    ]);
+    if (code === "0x") {
+      notFound();
+    }
+    return (
+      <main className="mx-auto max-w-5xl p-6">
+        <Search />
+        <h1 className="mb-4 text-2xl font-semibold">Contract Details</h1>
+        <div className="rounded border p-4">
+          <div className="mb-2 break-all font-mono">{address}</div>
+          <div>Balance: {formatEther(balance)} PGC</div>
+        </div>
+      </main>
+    );
+  } catch {
+    notFound();
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
-// app/page.tsx
 "use client";
 
 import { useEffect, useState } from "react";
+import Search from "@/components/search";
 
 type Block = { number: number; hash: string };
 
@@ -13,9 +13,8 @@ export default function Home() {
   useEffect(() => {
     async function run() {
       try {
-        // ここはダミーAPI。実環境の Explorer API に差し替えてください
         const res = await fetch(
-          process.env.NEXT_PUBLIC_EXPLORER_API + "/summary"
+          (process.env.NEXT_PUBLIC_EXPLORER_API || "") + "/summary"
         );
         const data = await res.json();
         setHeight(data.latestHeight);
@@ -31,27 +30,30 @@ export default function Home() {
 
   return (
     <main className="mx-auto max-w-5xl p-6">
-      <h1 className="text-3xl font-bold mb-4">PGirlsChain Explorer</h1>
+      <h1 className="text-3xl font-bold mb-6">PGirlsChain Explorer</h1>
+
+      <Search />
+
       {loading ? (
         <p>Loading…</p>
       ) : (
         <>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-            <div className="rounded-2xl shadow p-4">
+          <div className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="rounded-2xl p-4 shadow">
               <div className="text-sm opacity-70">Latest Height</div>
               <div className="text-2xl font-semibold">{height ?? "-"}</div>
             </div>
-            <div className="rounded-2xl shadow p-4">
-              <div className="text-sm opacity-70">Tx/s (mock)</div>
+            <div className="rounded-2xl p-4 shadow">
+              <div className="text-sm opacity-70">Tx/s</div>
               <div className="text-2xl font-semibold">—</div>
             </div>
-            <div className="rounded-2xl shadow p-4">
-              <div className="text-sm opacity-70">Peers (mock)</div>
+            <div className="rounded-2xl p-4 shadow">
+              <div className="text-sm opacity-70">Peers</div>
               <div className="text-2xl font-semibold">—</div>
             </div>
           </div>
 
-          <h2 className="text-xl font-semibold mb-2">Latest Blocks</h2>
+          <h2 className="mb-2 text-xl font-semibold">Latest Blocks</h2>
           <div className="grid gap-3">
             {latest.map((b) => (
               <div key={b.hash} className="rounded-xl border p-4">
@@ -65,3 +67,4 @@ export default function Home() {
     </main>
   );
 }
+

--- a/app/tx/[hash]/page.tsx
+++ b/app/tx/[hash]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from "next/navigation";
+import { createPublicClient, formatEther, http } from "viem";
+import Search from "@/components/search";
+
+const client = createPublicClient({
+  transport: http(process.env.NEXT_PUBLIC_RPC_URL || ""),
+});
+
+export default async function TxPage({ params }: { params: { hash: string } }) {
+  try {
+    const tx = await client.getTransaction({
+      hash: params.hash as `0x${string}`,
+    });
+    return (
+      <main className="mx-auto max-w-5xl p-6">
+        <Search />
+        <h1 className="mb-4 text-2xl font-semibold">Transaction Details</h1>
+        <div className="rounded border p-4">
+          <div className="mb-2 break-all font-mono">Hash: {tx.hash}</div>
+          <div>From: {tx.from}</div>
+          <div>To: {tx.to}</div>
+          <div>Value: {formatEther(tx.value)} PGC</div>
+        </div>
+      </main>
+    );
+  } catch {
+    notFound();
+  }
+}

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function Search() {
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    const q = query.trim();
+    if (/^0x[a-fA-F0-9]{64}$/.test(q)) {
+      router.push(`/tx/${q}`);
+    } else if (/^0x[a-fA-F0-9]{40}$/.test(q)) {
+      router.push(`/address/${q}`);
+    } else {
+      setError("Invalid search input");
+    }
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSearch} className="mb-8 flex">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            if (error) setError(null);
+          }}
+          placeholder="Search by Txn Hash / Address / Contract"
+          className="flex-1 rounded-l border px-3 py-2"
+        />
+        <button
+          type="submit"
+          className="rounded-r bg-blue-600 px-4 py-2 text-white"
+        >
+          Search
+        </button>
+      </form>
+      {error && <p className="mb-4 text-red-600">{error}</p>}
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- route search input to transaction or address pages
- add viem-backed transaction, address, and contract detail pages
- streamline home page with reusable search bar

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ca716c44833393df095859d95941