### PR TITLE
Fix dynamic page params for Next.js 15

### DIFF
--- a/app/address/[address]/page.tsx
+++ b/app/address/[address]/page.tsx
@@ -1,17 +1,20 @@
 import { notFound } from "next/navigation";
-import { createPublicClient, formatEther, http } from "viem";
+import { createPublicClient, formatUnits, http } from "viem";
 import Search from "@/components/search";
 
 const client = createPublicClient({
   transport: http(process.env.NEXT_PUBLIC_RPC_URL || ""),
 });
 
+const DECIMALS = 8;
+const SYMBOL = "PGIRLS";
+
 export default async function AddressPage({
   params,
 }: {
-  params: { address: string };
+  params: Promise<{ address: string }>;
 }) {
-  const address = params.address as `0x${string}`;
+  const address = (await params).address as `0x${string}`;
   try {
     const [balance, code] = await Promise.all([
       client.getBalance({ address }),
@@ -26,7 +29,7 @@ export default async function AddressPage({
         </h1>
         <div className="rounded border p-4">
           <div className="mb-2 break-all font-mono">{address}</div>
-          <div>Balance: {formatEther(balance)} PGC</div>
+          <div>Balance: {formatUnits(balance, DECIMALS)} {SYMBOL}</div>
           <div>Type: {isContract ? "Contract" : "Externally Owned Account"}</div>
         </div>
       </main>

--- a/app/contract/[address]/page.tsx
+++ b/app/contract/[address]/page.tsx
@@ -1,17 +1,20 @@
 import { notFound } from "next/navigation";
-import { createPublicClient, formatEther, http } from "viem";
+import { createPublicClient, formatUnits, http } from "viem";
 import Search from "@/components/search";
 
 const client = createPublicClient({
   transport: http(process.env.NEXT_PUBLIC_RPC_URL || ""),
 });
 
+const DECIMALS = 8;
+const SYMBOL = "PGIRLS";
+
 export default async function ContractPage({
   params,
 }: {
-  params: { address: string };
+  params: Promise<{ address: string }>;
 }) {
-  const address = params.address as `0x${string}`;
+  const address = (await params).address as `0x${string}`;
   try {
     const [balance, code] = await Promise.all([
       client.getBalance({ address }),
@@ -26,7 +29,7 @@ export default async function ContractPage({
         <h1 className="mb-4 text-2xl font-semibold">Contract Details</h1>
         <div className="rounded border p-4">
           <div className="mb-2 break-all font-mono">{address}</div>
-          <div>Balance: {formatEther(balance)} PGC</div>
+          <div>Balance: {formatUnits(balance, DECIMALS)} {SYMBOL}</div>
         </div>
       </main>
     );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect, useState } from "react";
 
+interface Block {
+  hash: string;
+  number: number;
+}
+
 export default function Home() {
   const [height, setHeight] = useState<number | null>(null);
   const [latest, setLatest] = useState<Block[]>([]);

--- a/app/tx/[hash]/page.tsx
+++ b/app/tx/[hash]/page.tsx
@@ -1,15 +1,23 @@
 import { notFound } from "next/navigation";
-import { createPublicClient, formatEther, http } from "viem";
+import { createPublicClient, formatUnits, http } from "viem";
 import Search from "@/components/search";
 
 const client = createPublicClient({
   transport: http(process.env.NEXT_PUBLIC_RPC_URL || ""),
 });
 
-export default async function TxPage({ params }: { params: { hash: string } }) {
+const DECIMALS = 8;
+const SYMBOL = "PGIRLS";
+
+export default async function TxPage({
+  params,
+}: {
+  params: Promise<{ hash: string }>;
+}) {
+  const hash = (await params).hash as `0x${string}`;
   try {
     const tx = await client.getTransaction({
-      hash: params.hash as `0x${string}`,
+      hash,
     });
     return (
       <main className="mx-auto max-w-5xl p-6">
@@ -19,7 +27,7 @@ export default async function TxPage({ params }: { params: { hash: string } }) {
           <div className="mb-2 break-all font-mono">Hash: {tx.hash}</div>
           <div>From: {tx.from}</div>
           <div>To: {tx.to}</div>
-          <div>Value: {formatEther(tx.value)} PGC</div>
+          <div>Value: {formatUnits(tx.value, DECIMALS)} {SYMBOL}</div>
         </div>
       </main>
     );


### PR DESCRIPTION
## Summary
- adapt contract and transaction pages to new Next.js 15 `params` typing
- define `Block` type on home page to satisfy TypeScript
- display PGIRLS values using 8-decimal units on transaction, address and contract pages

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*
- `curl -I https://explorer.rahabpunkaholicgirls.com/tx/0x86317e46963cfd9210d77277d148458bfcc05a96b54d7972ab498b12bd109a8e` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a400186858833393dc03481e7160d7