### PR TITLE
Fix transfer recipient display

### DIFF
--- a/app/tx/[hash]/page.tsx
+++ b/app/tx/[hash]/page.tsx
@@ -1,5 +1,11 @@
 import { notFound } from "next/navigation";
-
+import {
+  createPublicClient,
+  decodeEventLog,
+  formatUnits,
+  http,
+  parseAbiItem,
+} from "viem";
 import Search from "@/components/search";
 import { DECIMALS, SYMBOL } from "@/lib/constants";
 
@@ -7,6 +13,9 @@ const client = createPublicClient({
   transport: http(process.env.NEXT_PUBLIC_RPC_URL || ""),
 });
 
+const transferEvent = parseAbiItem(
+  "event Transfer(address indexed from, address indexed to, uint256 value)"
+);
 
 export default async function TxPage({
   params,
@@ -15,6 +24,32 @@ export default async function TxPage({
 }) {
   const hash = (await params).hash as `0x${string}`;
   try {
+    const [tx, receipt] = await Promise.all([
+      client.getTransaction({ hash }),
+      client.getTransactionReceipt({ hash }),
+    ]);
+
+    let value = tx.value;
+    let transferFrom = tx.from;
+    let transferTo = tx.to;
+
+    for (const log of receipt.logs) {
+      try {
+        const parsed = decodeEventLog({
+          abi: [transferEvent],
+          data: log.data,
+          topics: log.topics,
+        });
+        if (parsed.eventName === "Transfer") {
+          value = parsed.args.value as bigint;
+          transferFrom = parsed.args.from as `0x${string}`;
+          transferTo = parsed.args.to as `0x${string}`;
+          break;
+        }
+      } catch {
+        // not an ERC20 Transfer log
+      }
+    }
 
     return (
       <main className="mx-auto max-w-5xl p-6">
@@ -22,9 +57,11 @@ export default async function TxPage({
         <h1 className="mb-4 text-2xl font-semibold">Transaction Details</h1>
         <div className="rounded border p-4">
           <div className="mb-2 break-all font-mono">Hash: {tx.hash}</div>
-          <div>From: {tx.from}</div>
-          <div>To: {tx.to}</div>
-
+          <div>From: {transferFrom}</div>
+          <div>To: {transferTo}</div>
+          <div>
+            Value: {formatUnits(value, DECIMALS)} {SYMBOL}
+          </div>
         </div>
       </main>
     );
@@ -32,3 +69,4 @@ export default async function TxPage({
     notFound();
   }
 }
+


### PR DESCRIPTION
## Summary
- capture ERC20 Transfer from/to addresses from transaction receipt
- render transfer participants instead of raw tx from/to

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a410453a008333a9358de33bc1e314