### PR TITLE
Fix transfer recipient display

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { createPublicClient, http } from "viem";
+import Search from "@/components/search";
 
 interface Block {
   hash: `0x${string}`;
@@ -11,11 +12,6 @@ interface Block {
 const client = createPublicClient({
   transport: http(process.env.NEXT_PUBLIC_RPC_URL || ""),
 });
-
-interface Block {
-  hash: string;
-  number: number;
-}
 
 export default function Home() {
   const [height, setHeight] = useState<number | null>(null);
@@ -48,6 +44,8 @@ export default function Home() {
   return (
     <main className="mx-auto max-w-5xl p-6">
       <h1 className="text-3xl font-bold mb-6">PGirlsChain Explorer</h1>
+
+      <Search />
 
       {loading ? (
         <p>Loading…</p>

--- a/app/tx/[hash]/page.tsx
+++ b/app/tx/[hash]/page.tsx
@@ -1,5 +1,11 @@
 import { notFound } from "next/navigation";
-
+import {
+  createPublicClient,
+  decodeEventLog,
+  formatUnits,
+  http,
+  parseAbiItem,
+} from "viem";
 import Search from "@/components/search";
 import { DECIMALS, SYMBOL } from "@/lib/constants";
 
@@ -7,6 +13,9 @@ const client = createPublicClient({
   transport: http(process.env.NEXT_PUBLIC_RPC_URL || ""),
 });
 
+const transferEvent = parseAbiItem(
+  "event Transfer(address indexed from, address indexed to, uint256 value)"
+);
 
 export default async function TxPage({
   params,
@@ -15,6 +24,32 @@ export default async function TxPage({
 }) {
   const hash = (await params).hash as `0x${string}`;
   try {
+    const [tx, receipt] = await Promise.all([
+      client.getTransaction({ hash }),
+      client.getTransactionReceipt({ hash }),
+    ]);
+
+    let value = tx.value;
+    let transferFrom = tx.from;
+    let transferTo = tx.to;
+
+    for (const log of receipt.logs) {
+      try {
+        const parsed = decodeEventLog({
+          abi: [transferEvent],
+          data: log.data,
+          topics: log.topics,
+        });
+        if (parsed.eventName === "Transfer") {
+          value = parsed.args.value as bigint;
+          transferFrom = parsed.args.from as `0x${string}`;
+          transferTo = parsed.args.to as `0x${string}`;
+          break;
+        }
+      } catch {
+        // not an ERC20 Transfer log
+      }
+    }
 
     return (
       <main className="mx-auto max-w-5xl p-6">
@@ -22,9 +57,11 @@ export default async function TxPage({
         <h1 className="mb-4 text-2xl font-semibold">Transaction Details</h1>
         <div className="rounded border p-4">
           <div className="mb-2 break-all font-mono">Hash: {tx.hash}</div>
-          <div>From: {tx.from}</div>
-          <div>To: {tx.to}</div>
-
+          <div>From: {transferFrom}</div>
+          <div>To: {transferTo}</div>
+          <div>
+            Value: {formatUnits(value, DECIMALS)} {SYMBOL}
+          </div>
         </div>
       </main>
     );
@@ -32,3 +69,4 @@ export default async function TxPage({
     notFound();
   }
 }
+

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,2 +1,2 @@
-export const DECIMALS = 8;
+export const DECIMALS = 10;
 export const SYMBOL = "PGIRLS";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- capture ERC20 Transfer from/to addresses from transaction receipt
- render decoded transfer participants
- remove duplicate Block interface and type block hash as `0x{string}`
- target ES2020 so BigInt block iteration compiles
- correct PGIRLS token decimals and restore search form on home page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch fonts)


------
https://chatgpt.com/codex/tasks/task_e_68a410453a008333a9358de33bc1e314